### PR TITLE
feat(k8stress): Improve cluster lifecycle and robustness

### DIFF
--- a/cmd/benchdriver/main.go
+++ b/cmd/benchdriver/main.go
@@ -77,18 +77,6 @@ func getEnvOr(name, def string) string {
 	return v
 }
 
-func parseEnv[T any](name string, or T, parser func(string) (T, error)) (T, error) {
-	v := os.Getenv(name)
-	if v == "" {
-		return or, nil
-	}
-	parsed, err := parser(v)
-	if err != nil {
-		return or, fmt.Errorf("read env var %s: %w", name, err)
-	}
-	return parsed, nil
-}
-
 func loadK8sClusterRestConfig() (*rest.Config, error) {
 	config, inClusterErr := rest.InClusterConfig()
 	if inClusterErr != nil {

--- a/internal/worker/k8stress/instance.go
+++ b/internal/worker/k8stress/instance.go
@@ -22,6 +22,7 @@ import (
 	cnpgapi "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sync/errgroup"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -132,10 +133,6 @@ func (si *stressInstance) Run(ctx context.Context, op clusterOp) (err error) {
 
 	log.Printf("Starting stress instance %s", si.name)
 	defer log.Printf("Stopped stress instance %s", si.name)
-	ctx, cancel := ctxutil.WithFuncContext(ctx, func() {
-		log.Printf("Instance %s: stop signal received", si.name)
-	})
-	defer cancel()
 
 	defer func() {
 		err := ctx.Err()
@@ -157,17 +154,49 @@ func (si *stressInstance) Run(ctx context.Context, op clusterOp) (err error) {
 		return nil
 	}
 
-	cluster, err := si.createCluster(ctx)
+	// Set up force deletion that triggers 30 seconds after cancellation
+	//
+	// Note: We register the 'destroy' cluster operation before the 'create' operation.
+	//       This is to ensure that the cluster is destroyed if the 'create'
+	//       operation fails, but the resource was created anyways. For example
+	//       due to a network error after the instance was created within
+	//       Kubernetes.
+	//
+	//       The force deletion is triggered by a stop signal received during
+	//       the benchmark run. This is to ensure that the test really stops in case
+	//       the postgres clients are blocking the runner from completing the
+	//       cleanup. By deleting the DB we hopefully force an error on the
+	//       clients.
+	cleanupStarted := make(chan struct{})
+	ctx, cancel := ctxutil.WithFuncContext(ctx, func() {
+		log.Printf("Instance %s: stop signal received, starting force deletion timer", si.name)
+
+		go func() {
+			// Wait 30 seconds for normal cleanup to start
+			select {
+			case <-time.After(30 * time.Second):
+				log.Printf("Instance %s: normal cleanup timeout, starting force deletion", si.name)
+			case <-cleanupStarted:
+				log.Printf("Instance %s: normal cleanup started, waiting for completion", si.name)
+			}
+
+			log.Printf("Instance %s: performing cluster cleanup and deletion", si.name)
+			if err := si.destroyWithRetry(context.Background(), StressTestNamespace, si.name); err != nil {
+				metrics.ErrClusterDelete.WithLabelValues(si.owner.name).Inc()
+				log.Printf("ERROR destroying cluster: %v", err)
+			} else {
+				log.Printf("Instance %s: cluster cleanup completed successfully", si.name)
+			}
+		}()
+	})
+	defer cancel()
+	defer close(cleanupStarted) // notify context handler that we are handling a normal cleanup
+
+	cluster, err := si.createCluster(ctx, si.name)
 	if err != nil {
 		incNotCancelled(err, metrics.ErrClusterCreate.WithLabelValues(si.owner.name))
 		return fmt.Errorf("create cluster: %w", err)
 	}
-	defer func() {
-		if err := si.destroy(context.Background(), cluster); err != nil {
-			metrics.ErrClusterDelete.WithLabelValues(si.owner.name).Inc()
-			log.Printf("ERROR destroying cluster: %v", err)
-		}
-	}()
 
 	if cluster, err = si.waitClusterReady(ctx, cluster); err != nil {
 		incNotCancelled(err, metrics.ErrClusterCreate.WithLabelValues(si.owner.name))
@@ -386,8 +415,8 @@ func runStressStep(
 	return err
 }
 
-func (si *stressInstance) createCluster(ctx context.Context) (*cnpgapi.Cluster, error) {
-	log.Printf("Instance %s: creating cluster", si.name)
+func (si *stressInstance) createCluster(ctx context.Context, name string) (*cnpgapi.Cluster, error) {
+	log.Printf("Instance %s: creating cluster", name)
 
 	client, err := syscnpg.NewSystemClientForConfig(si.owner.tester.restConfig, StressTestNamespace)
 	if err != nil {
@@ -406,7 +435,7 @@ func (si *stressInstance) createCluster(ctx context.Context) (*cnpgapi.Cluster, 
 	labels[LabelStressUser] = si.owner.name
 
 	systemConfig := systems.SystemsConfig{
-		Name:      si.name,
+		Name:      name,
 		Namespace: StressTestNamespace,
 		Kind:      "cnpg",
 		Count:     1,
@@ -461,7 +490,34 @@ func (si *stressInstance) deregister() {
 	delete(si.registry.starting, si.name)
 }
 
-func (si *stressInstance) destroy(ctx context.Context, cluster *cnpgapi.Cluster) error {
+func (si *stressInstance) destroyWithRetry(ctx context.Context, namespace, name string) error {
+	log.Printf("Instance %s: destroying cluster with retry logic", si.name)
+
+	operation := func() (any, error) {
+		err := si.destroy(ctx, namespace, name)
+		if err != nil {
+			log.Printf("Instance %s: destroy attempt failed, will retry: %v", si.name, err)
+			return nil, err
+		}
+		return nil, nil
+	}
+
+	expBackoff := backoff.NewExponentialBackOff()
+	expBackoff.InitialInterval = 5 * time.Second
+	expBackoff.MaxInterval = 1 * time.Minute
+	expBackoff.Multiplier = 2.0
+
+	// Retry for up to 20 attempts with exponential backoff
+	_, err := backoff.Retry(ctx, operation, backoff.WithMaxTries(20))
+	if err != nil {
+		return fmt.Errorf("destroy with retry failed after all attempts: %w", err)
+	}
+
+	log.Printf("Instance %s: cluster destroyed successfully", si.name)
+	return nil
+}
+
+func (si *stressInstance) destroy(ctx context.Context, namespace, name string) error {
 	log.Printf("Instance %s: destroying cluster", si.name)
 
 	client, err := si.owner.tester.getCNPGClient()
@@ -469,8 +525,11 @@ func (si *stressInstance) destroy(ctx context.Context, cluster *cnpgapi.Cluster)
 		return fmt.Errorf("get cnpg client: %w", err)
 	}
 
-	log.Printf("Deleting cluster %s", cluster.Name)
-	if err := client.Clusters(cluster.Namespace).Delete(ctx, cluster.Name, metav1.DeleteOptions{}); err != nil {
+	log.Printf("Deleting cluster %s", name)
+	if err := client.Clusters(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
 		return fmt.Errorf("delete operation: %w", err)
 	}
 	return nil

--- a/internal/worker/k8stress/user.go
+++ b/internal/worker/k8stress/user.go
@@ -234,8 +234,6 @@ func (u *stressUser) deleteCluster(ctx context.Context) (bool, error) {
 	}
 
 	inst.cancel()
-	delete(u.registry.active, inst.name)
-	delete(u.registry.instances, inst.name)
 
 	return true, nil
 }
@@ -254,14 +252,18 @@ func createTimer(dist *benchdriverapi.JitterDuration, def prop.UniformJitterDura
 func selectOp(active, total, min, max int) clusterOp {
 	log.Println("selectOp:", active, total, min, max)
 
-	switch active {
+	switch total {
 	case 0:
 		return clusterOpCreate
-	case max:
-		return clusterOpDelete
 	default:
+		if total >= max {
+			return clusterOpDelete
+		}
+		if total < min {
+			return clusterOpCreate
+		}
 		// The deletion probability is higher the more instances we have in the cluster
-		if prop.Bool(float64(active-min) / float64(max-min)).Next() {
+		if prop.Bool(float64(total-min) / float64(max-min)).Next() {
 			return clusterOpDelete
 		}
 


### PR DESCRIPTION
Make k8stress cluster management more robust and reliable.

This change introduces several improvements to the k8stress worker to prevent orphaned resources and make the test more stable.

Key changes:
- Implement a force deletion mechanism with a 30-second timeout to ensure clusters are always cleaned up if the main cleanup process hangs.
- Introduce retry logic with exponential backoff for cluster deletion to handle transient Kubernetes API errors.
- Refine the cluster operation selection logic (selectOp) to better manage the number of concurrent clusters between min/max thresholds.
- The instance now manages its own cleanup via context cancellation, simplifying the user loop.